### PR TITLE
feat: add support to get vmapAdsRequest from customData

### DIFF
--- a/src/receiver-manager.js
+++ b/src/receiver-manager.js
@@ -59,6 +59,7 @@ class ReceiverManager {
     this._reset();
     return new Promise((resovle, reject) => {
       const mediaInfo = loadRequestData.media.customData.mediaInfo;
+      this._maybeCreateVmapAdsRequest(loadRequestData.media);
       this._maybeReplaceAdTagCorrelator(loadRequestData.media);
       this._eventManager.listen(this._player, this._player.Event.ERROR, event => reject(event));
       this._eventManager.listen(this._player, this._player.Event.SOURCE_SELECTED, event => this._onSourceSelected(event, loadRequestData, resovle));
@@ -208,6 +209,12 @@ class ReceiverManager {
         break;
       default:
         break;
+    }
+  }
+
+  _maybeCreateVmapAdsRequest(media: Object): Object {
+    if (media.customData && media.customData.vmapAdsRequest) {
+      media.vmapAdsRequest = media.customData.vmapAdsRequest;
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

For Android & iOS cast SDKs which are not supported vmapAdsRequest, enable to pass this
config with our customData.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
