### PR TITLE
fix(FEC-8552): when seeking a video by dragging the scrubber, the scrubber jumps back before it reaches the seek point

### DIFF
--- a/src/receiver-manager.js
+++ b/src/receiver-manager.js
@@ -160,6 +160,8 @@ class ReceiverManager {
       }
       // Workaround to avoid Live & Dvr seek issue
       this._playerManager.removeSupportedMediaCommands(cast.framework.messages.Command.SEEK);
+    } else if (!this._player.isLive()) {
+      this._playerManager.addSupportedMediaCommands(cast.framework.messages.Command.SEEK);
     }
   }
 

--- a/src/receiver-manager.js
+++ b/src/receiver-manager.js
@@ -55,8 +55,6 @@ class ReceiverManager {
       [CUSTOM_CHANNEL]: cast.framework.system.MessageType.JSON
     };
     Utils.Object.mergeDeep(defaultOptions, options);
-    // Workaround to avoid Live & Dvr seek issue
-    this._playerManager.removeSupportedMediaCommands(cast.framework.messages.Command.SEEK);
     this._logger.debug('Start receiver', defaultOptions);
     this._context.start(defaultOptions);
   }
@@ -155,9 +153,13 @@ class ReceiverManager {
   }
 
   _handleLiveDvr(loadRequestData: Object): void {
-    if (this._player.isDvr() && loadRequestData.currentTime === LIVE_EDGE) {
-      loadRequestData.currentTime = null;
-      this._logger.debug(`Live DVR will seek to live edge`);
+    if (this._player.isDvr()) {
+      if (loadRequestData.currentTime === LIVE_EDGE) {
+        loadRequestData.currentTime = null;
+        this._logger.debug(`Live DVR will seek to live edge`);
+      }
+      // Workaround to avoid Live & Dvr seek issue
+      this._playerManager.removeSupportedMediaCommands(cast.framework.messages.Command.SEEK);
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

remove seek option only for live (currently removes also for vod)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
