### PR TITLE
fix(FEC-8610): set currentTime to null isn't seek the stream to the live edge

### DIFF
--- a/src/receiver-manager.js
+++ b/src/receiver-manager.js
@@ -155,7 +155,7 @@ class ReceiverManager {
   _handleLiveDvr(loadRequestData: Object): void {
     if (this._player.isDvr()) {
       if (loadRequestData.currentTime === LIVE_EDGE) {
-        loadRequestData.currentTime = null;
+        delete loadRequestData.currentTime;
         this._logger.debug(`Live DVR will seek to live edge`);
       }
       // Workaround to avoid Live & Dvr seek issue


### PR DESCRIPTION
### Description of the Changes

Need to delete it, i.e. to set it to undefined.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
